### PR TITLE
[ADDS] roles and rolebindings folders to base kustomization file

### DIFF
--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -10,4 +10,6 @@ resources:
   - sealedSecrets
   - services
   - statefulSets
+  - roles
+  - roleBindings
   - ingress.yaml


### PR DESCRIPTION
"roles" and "rolebindings" directories are now tracked by base kustomization files and are handled by the setup script like the other directories containing kubernernetes object YAMLs